### PR TITLE
fix: upgrade mt dom api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- Updated `svgbob` to 0.6.6. (Fixes the compilation failure due to a breaking dependency change in `svgbob` 0.6.6.)
+
 ## [0.3.0-alpha.4] - 2021-12-18
 
 - Added Consolas to the diagram font list.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ enable = ["svgbob"]
 [dependencies]
 syn = "1.0.41"
 quote = "1"
-svgbob = { version = "0.6", optional = true }
+svgbob = { version = "0.6.6", optional = true }
 proc-macro2 = "1"
 base64 = ">= 0.5.2, < 0.14"
 unicode-width = "0.1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2021-06-05"  # targetting 1.54, which hasn't been released yet
+channel = "1.56"

--- a/src/textproc.rs
+++ b/src/textproc.rs
@@ -294,8 +294,10 @@ fn to_svg(art: &str) -> String {
                 // to `<text>` elements.
                 let mut width = 0;
                 for child in elem.get_children() {
-                    if let Some(text) = child.text() {
-                        width += xml_text_width(text);
+                    if let Node::Leaf(leaf) = child {
+                        if leaf.is_text() {
+                            width += xml_text_width(leaf.unwrap_text());
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fix compile error:
```bash
error[E0599]: no method named `text` found for reference `&Node<&str, &str, svgbob::sauron::prelude::Leaf, &str, AttributeValue<()>>` in the current scope
   --> src\textproc.rs:297:47
    |
297 |                     if let Some(text) = child.text() {
    |                                               ^^^^ method not found in `&Node<&str, &str, svgbob::sauron::prelude::Leaf, &str, AttributeValue<()>>`
```