### PR TITLE
chore: upgrade base64 to 0.21 and bump version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.60
+      - uses: dtolnay/rust-toolchain@1.60.0
         with:
           components: clippy
       - name: cargo clippy
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.60
+      - uses: dtolnay/rust-toolchain@1.60.0
       - name: Test
         run: cargo test -p svgbobdoc
       - name: Test with feature `enable`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.60.0
+      - uses: dtolnay/rust-toolchain@1.61.0
         with:
           components: clippy
       - name: cargo clippy
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.60.0
+      - uses: dtolnay/rust-toolchain@1.61.0
       - name: Test
         run: cargo test -p svgbobdoc
       - name: Test with feature `enable`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.61.0
+      - uses: dtolnay/rust-toolchain@1.65.0
         with:
           components: clippy
       - name: cargo clippy
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.61.0
+      - uses: dtolnay/rust-toolchain@1.65.0
       - name: Test
         run: cargo test -p svgbobdoc
       - name: Test with feature `enable`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,40 +8,19 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
-      # - uses: actions-rs/toolchain@v1
-      # "Fully support modern toolchain file #166"
-      # <https://github.com/actions-rs/toolchain/pull/166>
-      - uses: codota/toolchain@00a8bf2bdcfe93aefd70422d3dec07337959d3a4
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.60
         with:
-          profile: minimal
           components: clippy
-      - name: cargo clippy
-        uses: actions-rs/clippy-check@v1.0.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: -p svgbobdoc --all-features
+      - run: rustup component add clippy
+      - run: cargo clippy -p svgbobdoc --all-features
 
   test:
     name: Test
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
-      # - uses: actions-rs/toolchain@v1
-      # "Fully support modern toolchain file #166"
-      # <https://github.com/actions-rs/toolchain/pull/166>
-      - uses: codota/toolchain@00a8bf2bdcfe93aefd70422d3dec07337959d3a4
-        with:
-          profile: minimal
-          components: clippy
-      - name: cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -p svgbobdoc
-      - name: cargo test with `enable`
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -p svgbobdoc --features enable
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.6)
+      - run: cargo test -p svgbobdoc
+      - run: cargo test -p svgbobdoc --features enable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.60
         with:
           components: clippy
-      - run: rustup component add clippy
-      - run: cargo clippy -p svgbobdoc --all-features
+      - name: cargo clippy
+        run: cargo clippy -p svgbobdoc --all-features
 
   test:
     name: Test
@@ -21,6 +21,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.6)
-      - run: cargo test -p svgbobdoc
-      - run: cargo test -p svgbobdoc --features enable
+      - uses: dtolnay/rust-toolchain@1.60
+      - name: Test
+        run: cargo test -p svgbobdoc
+      - name: Test with feature `enable`
+        run: cargo test -p svgbobdoc --features enable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "svgbobdoc"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["yvt <i@yvt.jp>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
@@ -24,7 +24,7 @@ syn = "1.0.41"
 quote = "1"
 svgbob = { version = "= 0.6.6", optional = true }
 proc-macro2 = "1"
-base64 = ">= 0.5.2, < 0.14"
+base64 = "0.21.5"
 unicode-width = "0.1"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This crate provides a procedural macro that renders
 ASCII diagrams in doc comments as SVG images using [`svgbob`].
 
-*Requires Rust version 1.54 or later or equivalent nightly builds.*
+*Requires Rust version 1.60 or later or equivalent nightly builds.*
 
 [`svgbob`]: https://github.com/ivanceras/svgbob
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.60.0"
+channel = "1.61.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.61.0"
+channel = "1.65.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.56"
+channel = "1.60"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.60"
+channel = "1.60.0"

--- a/src/textproc.rs
+++ b/src/textproc.rs
@@ -1,3 +1,4 @@
+use base64::{Engine as _, engine::general_purpose};
 use proc_macro2::Span;
 use syn::{Error, Result};
 
@@ -257,7 +258,7 @@ fn convert_diagram(art: &str, output: &mut String, params: CodeBlockParams) {
 
     // Output the SVG as an image element
     use std::fmt::Write;
-    let svg_base64 = base64::encode(&*svg_code);
+    let svg_base64 = general_purpose::STANDARD.encode(&*svg_code);
 
     if let Some(label) = params.label {
         writeln!(


### PR DESCRIPTION
Hi there, this PR helps upgrade the base64 dependency to the latest version.  The previous base64 v0.13.1 is outdated.

Also, could you please consider releasing this to crates.io after merge? Thanks!