### PR TITLE
ci: Upgrade CI actions to dtonlay toolchain.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,40 +8,23 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
-      # - uses: actions-rs/toolchain@v1
-      # "Fully support modern toolchain file #166"
-      # <https://github.com/actions-rs/toolchain/pull/166>
-      - uses: codota/toolchain@00a8bf2bdcfe93aefd70422d3dec07337959d3a4
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          components: clippy
+          toolchain: 1.73.0
       - name: cargo clippy
-        uses: actions-rs/clippy-check@v1.0.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: -p svgbobdoc --all-features
+        run: cargo clippy -p svgbobdoc --all-features
 
   test:
     name: Test
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
-      # - uses: actions-rs/toolchain@v1
-      # "Fully support modern toolchain file #166"
-      # <https://github.com/actions-rs/toolchain/pull/166>
-      - uses: codota/toolchain@00a8bf2bdcfe93aefd70422d3dec07337959d3a4
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          components: clippy
+          toolchain: 1.73.0
       - name: cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -p svgbobdoc
+        run: cargo test -p svgbobdoc
       - name: cargo test with `enable`
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -p svgbobdoc --features enable
+        run: cargo test -p svgbobdoc --features enable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.73.0
       - name: cargo clippy
         run: cargo clippy -p svgbobdoc --all-features
 
@@ -21,9 +18,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.73.0
       - name: cargo test
         run: cargo test -p svgbobdoc
       - name: cargo test with `enable`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.56"
+channel = "1.73"


### PR DESCRIPTION
Actions-rs has been deprecated. Use dtonlay actions instead.